### PR TITLE
Refactor/routine settings

### DIFF
--- a/src/controllers/settings/settings.controller.ts
+++ b/src/controllers/settings/settings.controller.ts
@@ -61,7 +61,8 @@ export class SettingsController {
       companyId,
     };
 
-    const createdSettings = await this.routineSettings.createRoutineSettings(
+    const createdSettings = await this.routineSettings.upsertRoutineSettings(
+      { companyId },
       settingsWithCompany,
     );
 

--- a/src/controllers/settings/settings.controller.ts
+++ b/src/controllers/settings/settings.controller.ts
@@ -40,9 +40,11 @@ export class SettingsController {
       this.nats.send('core-ports.get-companies', {}),
     );
 
-    companies.forEach((company) => {
-      this.createSettings(user, company.id, settings);
+    const createPromises = companies.map((company) => {
+      return this.createSettings(user, company.id, settings);
     });
+
+    await Promise.all(createPromises);
   }
 
   @Post('/:companyId')

--- a/src/scripts/global-routine-settings.ts
+++ b/src/scripts/global-routine-settings.ts
@@ -24,7 +24,7 @@ async function bootstrap() {
 
   const baseSettings = {
     disabledTeams: [],
-    cron: '* * * * 5',
+    cron: '0 0 * * 5',
   };
 
   await settings.globalRoutineSettingsCreation(user, baseSettings);

--- a/src/scripts/global-routine-settings.ts
+++ b/src/scripts/global-routine-settings.ts
@@ -14,7 +14,12 @@ async function bootstrap() {
     picture: '*.jpg',
     teams: [],
     companies: [],
-    permissions: ['routines:update:own', 'routines:update:any'],
+    permissions: [
+      'routines:create:team',
+      'routines:create:any',
+      'routines:update:team',
+      'routines:update:any',
+    ],
   };
 
   const baseSettings = {

--- a/src/scripts/global-routine-settings.ts
+++ b/src/scripts/global-routine-settings.ts
@@ -29,10 +29,5 @@ async function bootstrap() {
 
   await settings.globalRoutineSettingsCreation(user, baseSettings);
   await app.close();
-
-  const timeoutInMS = 10 * 60 * 1000;
-  setTimeout(() => {
-    process.exit();
-  }, timeoutInMS);
 }
 bootstrap();

--- a/src/services/routineSettings.service.ts
+++ b/src/services/routineSettings.service.ts
@@ -40,6 +40,17 @@ export class RoutineSettingsService {
     });
   }
 
+  async upsertRoutineSettings(
+    where: Prisma.RoutineSettingsWhereUniqueInput,
+    data: Prisma.RoutineSettingsCreateInput,
+  ): Promise<RoutineSettings> {
+    return this.prisma.routineSettings.upsert({
+      where,
+      create: data,
+      update: data,
+    });
+  }
+
   async updateRoutineSettings(params: {
     where: Prisma.RoutineSettingsWhereUniqueInput;
     data: Prisma.RoutineSettingsUpdateInput;


### PR DESCRIPTION
## 🎢 Motivation

Allow routine settings script to be executed every deploy

## 🔧 Solution

- Remove the necessity of timeout;
- Change create for upsert;

## 🚨  Testing

Start the business API before starting testing this feature;
- Execute the `global:settings` command;
- Check if the settings are present on the database;


## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
