### PR TITLE
fix(settings): do not update routine settings if setting already exists

### DIFF
--- a/src/controllers/settings/settings.controller.test.ts
+++ b/src/controllers/settings/settings.controller.test.ts
@@ -89,6 +89,7 @@ describe('Settings Controller', () => {
           ...settings,
           companyId: company.id,
         },
+        {},
       );
     });
 

--- a/src/controllers/settings/settings.controller.ts
+++ b/src/controllers/settings/settings.controller.ts
@@ -64,6 +64,7 @@ export class SettingsController {
     const createdSettings = await this.routineSettings.upsertRoutineSettings(
       { companyId },
       settingsWithCompany,
+      {},
     );
 
     const routineNotificationData = {

--- a/src/scripts/global-routine-settings.ts
+++ b/src/scripts/global-routine-settings.ts
@@ -24,7 +24,7 @@ async function bootstrap() {
 
   const baseSettings = {
     disabledTeams: [],
-    cron: '0 0 * * 5',
+    cron: '0 0 * * 1',
   };
 
   await settings.globalRoutineSettingsCreation(user, baseSettings);

--- a/src/services/routineSettings.service.ts
+++ b/src/services/routineSettings.service.ts
@@ -48,12 +48,13 @@ export class RoutineSettingsService {
 
   async upsertRoutineSettings(
     where: Prisma.RoutineSettingsWhereUniqueInput,
-    data: Prisma.RoutineSettingsCreateInput,
+    createData: Prisma.RoutineSettingsCreateInput,
+    updateData: Partial<Prisma.RoutineSettingsCreateInput>,
   ): Promise<RoutineSettings> {
     return this.prisma.routineSettings.upsert({
       where,
-      create: data,
-      update: data,
+      create: createData,
+      update: updateData,
     });
   }
 


### PR DESCRIPTION
## 🎢 Motivation

The current way, all the routines would be erased on every script execution

## 🔧 Solution

Do not update routine settings if the setting already exists

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
