### PR TITLE
fix(overview): limit avarage number to one decimal

### DIFF
--- a/src/controllers/answers/answers.controller.test.ts
+++ b/src/controllers/answers/answers.controller.test.ts
@@ -296,7 +296,7 @@ describe('Answers Controller', () => {
           id: '1',
           answers: [
             { value: 1, questionId: '1' },
-            { value: 3, questionId: '2' },
+            { value: 5, questionId: '2' },
             { value: 'n', questionId: '3' },
           ],
           timestamp: '2022-09-15T11:09:31.143Z',
@@ -316,7 +316,7 @@ describe('Answers Controller', () => {
           id: '1',
           answers: [
             { value: 1, questionId: '1' },
-            { value: 3, questionId: '2' },
+            { value: 2, questionId: '2' },
             { value: 'y', questionId: '3' },
           ],
           timestamp: '2022-09-15T11:09:31.143Z',
@@ -348,7 +348,7 @@ describe('Answers Controller', () => {
           ],
           productivity: [
             {
-              average: 3,
+              average: 3.3,
               timestamp: '2022-09-15T11:09:31.143Z',
             },
           ],

--- a/src/controllers/answers/answers.controller.ts
+++ b/src/controllers/answers/answers.controller.ts
@@ -234,7 +234,7 @@ export class AnswersController {
 
         return {
           timestamp: answerGroupWithQuestionAnswers.timestamp,
-          average: mean,
+          average: Number(mean.toFixed(1)),
         };
       });
     });


### PR DESCRIPTION
## 🎢 Motivation

Overview numbers overlapping
![image](https://user-images.githubusercontent.com/5860206/198353004-24bb9057-bdaa-49ee-847d-4d2b9cd5814f.png)

## 🔧 Solution

Set average numbers to fixed 1

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
