### PR TITLE
fix(pending-routines)

### DIFF
--- a/src/controllers/pending-routines/pending-routines.controller.ts
+++ b/src/controllers/pending-routines/pending-routines.controller.ts
@@ -59,10 +59,10 @@ export class PendingRoutinesController {
     const answerUtc = dayjs(answerDate).utc();
     const answerUtcDate = answerUtc.toDate();
 
-    const timeSpanForAnwser = this.routine.getTimeSpanForAnwser();
+    const timeSpanForAnwser = this.cron.getTimespan(cronExpression);
     const answeredWithinTimeSpan = this.answerGroup.answeredWithinTimeSpan(
       answerUtcDate,
-      timeSpanForAnwser,
+      timeSpanForAnwser.startDate,
     );
 
     if (answeredWithinTimeSpan) {

--- a/src/services/answerGroup.service.ts
+++ b/src/services/answerGroup.service.ts
@@ -93,10 +93,7 @@ export class AnswerGroupService {
   }
 
   answeredWithinTimeSpan(answerDate: Date, timeSpanForAnwser: Date): boolean {
-    return (
-      dayjs(answerDate).isSame(timeSpanForAnwser, 'day') ??
-      dayjs(answerDate).isAfter(timeSpanForAnwser)
-    );
+    return dayjs(answerDate).isAfter(timeSpanForAnwser);
   }
 
   parseAnswerTimestamp(

--- a/src/services/answerGroup.service.ts
+++ b/src/services/answerGroup.service.ts
@@ -92,12 +92,8 @@ export class AnswerGroupService {
     return latestAnswer;
   }
 
-  answeredWithinTimeSpan(answerDate: Date, timeSpanForAnwser: number): boolean {
-    const todayUtcDate = dayjs().utc();
-    const differenceInDaysFromToday = todayUtcDate.diff(answerDate, 'day');
-    const answeredWithinTimeSpan =
-      differenceInDaysFromToday <= timeSpanForAnwser;
-    return answeredWithinTimeSpan;
+  answeredWithinTimeSpan(answerDate: Date, timeSpanForAnwser: Date): boolean {
+    return dayjs(answerDate).isAfter(timeSpanForAnwser);
   }
 
   parseAnswerTimestamp(

--- a/src/services/answerGroup.service.ts
+++ b/src/services/answerGroup.service.ts
@@ -93,7 +93,10 @@ export class AnswerGroupService {
   }
 
   answeredWithinTimeSpan(answerDate: Date, timeSpanForAnwser: Date): boolean {
-    return dayjs(answerDate).isAfter(timeSpanForAnwser);
+    return (
+      dayjs(answerDate).isSame(timeSpanForAnwser, 'day') ??
+      dayjs(answerDate).isAfter(timeSpanForAnwser)
+    );
   }
 
   parseAnswerTimestamp(

--- a/src/services/cron.service.ts
+++ b/src/services/cron.service.ts
@@ -54,6 +54,7 @@ export class CronService {
 
     const isRunningDate = previousRunDate.diff(currentDate, 'days') === 0;
     if (isRunningDate) {
+      cronExpression.next();
       return 0;
     }
 

--- a/src/services/cron.service.ts
+++ b/src/services/cron.service.ts
@@ -65,9 +65,12 @@ export class CronService {
   }
 
   getTimespan(cronExpression: cronParser.CronExpression): Timespan {
-    const startDate = cronExpression.prev().toDate();
+    const startDate = dayjs(cronExpression.prev().toDate())
+      .startOf('day')
+      .toDate();
     const finishDate = dayjs(cronExpression.next().toDate())
       .subtract(1, 'day')
+      .startOf('day')
       .toDate();
     cronExpression.prev();
     return {


### PR DESCRIPTION
## 🎢 Motivation

Routine reminders were not showing on the modal for people who replied to the routine a few days before the next execution

## 🔧 Solution

Consider the routine timespan for pending routines instead of 7 days.

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
