### PR TITLE
[EPD-48] Fix: create settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,11 +72,6 @@
     "wait-for-expect": "^3.0.2"
   },
   "jest": {
-    "globals": {
-      "ts-jest": {
-        "compiler": "ttypescript"
-      }
-    },
     "moduleFileExtensions": [
       "js",
       "json",
@@ -85,7 +80,9 @@
     "rootDir": "src",
     "testRegex": ".test\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
+      "^.+\\.(t|j)s$": ["ts-jest", {
+          "compiler": "ttypescript"
+      }]
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/prisma/migrations/20221117150554_settings_default_cron/migration.sql
+++ b/prisma/migrations/20221117150554_settings_default_cron/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "RoutineSettings" ALTER COLUMN "cron" SET DEFAULT '0 6 * * 5';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,7 +18,7 @@ model RoutineSettings {
   id    String       @db.Uuid   @id   @default(uuid())
   companyId String   @db.Uuid   @unique
   disabledTeams String[]
-  cron String
+  cron String @default("0 6 * * 5")
 }
 
 model AnswerGroup {

--- a/src/controllers/settings/settings.controller.test.ts
+++ b/src/controllers/settings/settings.controller.test.ts
@@ -90,7 +90,7 @@ describe('Settings Controller', () => {
           ...settings,
           companyId: company.id,
         },
-        {},
+        { cron: settings.cron },
       );
     });
 
@@ -110,11 +110,11 @@ describe('Settings Controller', () => {
 
       // Assert
       expect(emitMock).toBeCalledTimes(2);
-      expect(emitMock).toBeCalledWith('createSchedule', {
+      expect(emitMock).toBeCalledWith('updateSchedule', {
         ...createdSettings,
         queue: 'routine-notification',
       });
-      expect(emitMock).toBeCalledWith('createSchedule', {
+      expect(emitMock).toHaveBeenLastCalledWith('updateSchedule', {
         ...createdSettings,
         queue: 'routine-reminder-notification',
         cron: '0 0 * * 2',

--- a/src/controllers/settings/settings.controller.test.ts
+++ b/src/controllers/settings/settings.controller.test.ts
@@ -77,7 +77,8 @@ describe('Settings Controller', () => {
       );
 
       // Act
-      await controller.createSettings(userMock, company.id, settings);
+      const params = { companyId: company.id };
+      await controller.createSettings(userMock, params, settings);
 
       // Assert
       expect(routineSettingsServiceMock.upsertRoutineSettings).toBeCalledTimes(
@@ -104,7 +105,8 @@ describe('Settings Controller', () => {
       );
 
       // Act
-      await controller.createSettings(userMock, company.id, settings);
+      const params = { companyId: company.id };
+      await controller.createSettings(userMock, params, settings);
 
       // Assert
       expect(emitMock).toBeCalledTimes(2);
@@ -126,9 +128,10 @@ describe('Settings Controller', () => {
       );
 
       // Act
+      const params = { companyId: company.id };
       const savedRoutine = await controller.createSettings(
         userMock,
-        company.id,
+        params,
         settings,
       );
 

--- a/src/controllers/settings/settings.controller.test.ts
+++ b/src/controllers/settings/settings.controller.test.ts
@@ -178,10 +178,14 @@ describe('Settings Controller', () => {
       await controller.globalRoutineSettingsCreation(userMock, settings);
 
       expect(createSettingsMock).toBeCalledTimes(2);
-      expect(createSettingsMock).toBeCalledWith(userMock, company.id, settings);
       expect(createSettingsMock).toBeCalledWith(
         userMock,
-        otherCompany.id,
+        { companyId: company.id },
+        settings,
+      );
+      expect(createSettingsMock).toBeCalledWith(
+        userMock,
+        { companyId: otherCompany.id },
         settings,
       );
     });

--- a/src/controllers/settings/settings.controller.ts
+++ b/src/controllers/settings/settings.controller.ts
@@ -41,7 +41,7 @@ export class SettingsController {
     );
 
     const createPromises = companies.map((company) => {
-      return this.createSettings(user, company.id, settings);
+      return this.createSettings(user, { companyId: company.id }, settings);
     });
 
     await Promise.all(createPromises);
@@ -50,7 +50,7 @@ export class SettingsController {
   @Post('/:companyId')
   async createSettings(
     @User() user: UserType,
-    @Param() companyId: string,
+    @Param() { companyId }: { companyId: string },
     @Body() settings: SettingsWithoutCompany,
   ): Promise<RoutineSettings> {
     this.security.userHasPermission(user.permissions, 'routines:create:team');


### PR DESCRIPTION
## 🎢 Motivation

A rota para criar configurações de empresas não esta funcionando.

## 🔧 Solution

Alterar a rota para que ela volte a funcionar e aproveitar para mover a configuração de cron ser gerado internamente, para não precisar mudar diretamente no front.

Para revisar, aconselho olhar commit a commit para ver como foi sendo desenvolvido, talvez seja mais fácil de analisar.

## 🚨  Testing

Só rodar `npm test` (ps: precisando criar testes e2e, mas precisamos simplificar a implementação)

## 🃏 Task Card

Link to issue on Jira

- [`EPD-48`](https://getbud.atlassian.net/browse/EPD-48)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- budproj/execution-mode#339

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [x] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [x] Diego
